### PR TITLE
Honor --cc diffs as well

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -43,7 +43,7 @@ function splitByFile( diff ) {
 
 		if ( line.charAt( 0 ) === "d" ) {
 			isEmpty = false;
-			filename = line.replace( /^diff --[git|cc] a\/(\S+).*$/, "$1" );
+			filename = line.replace( /^diff --(?:cc |git a\/)(\S+).*$/, "$1" );
 			files[ filename ] = [];
 		}
 

--- a/diff.js
+++ b/diff.js
@@ -1,8 +1,10 @@
 var spawn = require( "child_process" ).spawn;
 
 module.exports = function( args, fn ) {
-	var childArgs = args ? [ "diff" ].concat( args.split( /\s/ ) ) : [ "diff" ],
-		child = spawn( "git", childArgs ),
+	var childArgs = args ? [ "diff" ].concat( args.split( /\s/ ) ) : [ "diff" ];
+	childArgs.push('--no-color');
+
+	var	child = spawn( "git", childArgs ),
 		stdout = "",
 		stderr = "";
 

--- a/diff.js
+++ b/diff.js
@@ -43,7 +43,7 @@ function splitByFile( diff ) {
 
 		if ( line.charAt( 0 ) === "d" ) {
 			isEmpty = false;
-			filename = line.replace( /^diff --git a\/(\S+).*$/, "$1" );
+			filename = line.replace( /^diff --[git|cc] a\/(\S+).*$/, "$1" );
 			files[ filename ] = [];
 		}
 


### PR DESCRIPTION
as mentioned in #20, 

Any merge conflict will end up with `diff --cc` instead of `diff --git`.

<hr>

I was thinking of using a shortformat style to pick up the filenames, like so… 

```bash
/chromium/src/third_party/WebKit/Source/devtools on heads/master ⁂
$ git diff --stat
 Source/devtools/front_end/timeline/TimelinePanel.js | Unmerged
 Source/devtools/front_end/timeline/TimelinePanel.js |  5 +++++
 Source/devtools/front_end/ui/Dialog.js              | Unmerged
 Source/devtools/front_end/ui/Dialog.js              | 20 ++++++++++++++++++++
 2 files changed, 25 insertions(+)

~/chromium/src/third_party/WebKit/Source/devtools on heads/master ⁂
$ git diff --numstat
0       0       Source/devtools/front_end/timeline/TimelinePanel.js
5       0       Source/devtools/front_end/timeline/TimelinePanel.js
0       0       Source/devtools/front_end/ui/Dialog.js
20      0       Source/devtools/front_end/ui/Dialog.js
```

... but that doesn't really work with the text splitting thing you got going.
<hr>

anyway this works!
fixes #20