### PR TITLE
Upgraded open to remove security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,18 @@
       "resolved": "https://registry.npmjs.org/github-request/-/github-request-1.2.4.tgz",
       "integrity": "sha1-SPZN26rSH9gF+12X9aVUh0R7+0k="
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
     "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "github-request": "1.2.4",
-    "open": "0.0.5"
+    "open": "6.4.0"
   }
 }


### PR DESCRIPTION
The old version of `open` is very old and has a security vulnerability. The current npm open is a different package with a changed API, but  pretty-diff make no use of breaking changes. Hence a simple package.json update is all that was needed. 